### PR TITLE
Fix odds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+data/
 target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
+++ b/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
@@ -220,7 +220,7 @@ public class AnalysisService {
         OddsUtils.getOddsForUnboxType(selectedUnboxType).forEach((rarity, chance) -> {
             double calculatedOdds = round((unboxedRarities.getOrDefault(rarity, 0) / totalUnboxed) * 100, 2);
             String amountAndTotal = unboxedRarities.getOrDefault(rarity, 0) + "/" + (int) totalUnboxed;
-            logToConsoleAndFile(format(rarity.toString(), 8, false) + " | " + format(amountAndTotal, 15, true) + " (~" + format(calculatedOdds + "", 6, true) + " %) | " + format(chance * 100 + "", 5, true) + "%");
+            logToConsoleAndFile(format(rarity.toString(), 8, false) + " | " + format(amountAndTotal, 15, true) + " (~" + format(calculatedOdds + "", 6, true) + " %) | " + format(round(chance * 100, 3) + "", 5, true) + "%");
         });
     }
 

--- a/src/main/java/de/cantry/csgocasestatsviewerv2/util/OddsUtils.java
+++ b/src/main/java/de/cantry/csgocasestatsviewerv2/util/OddsUtils.java
@@ -17,14 +17,26 @@ public class OddsUtils {
             odds.put(Rarity.gold, 0.0026);
             return odds;
         }
+
+        // Calculate odds to be inline with official odds from Valve (CSGO China)
+        // https://www.csgo.com.cn/news/gamebroad/20170911/206155.shtml
+        //
+        // Logic: Each tier should be 5x as rare as the previous tier (with the
+        // exception of knives, case hardcoded above)
+        // In the case of capsule cases with tiers blue, purple and pink,
+        // odds should be 25/31 (80.645%), 5/31 (16.129%) and 1/31 (3.226%)
+        // The denominator of 31 is obtained by doing 1+5+25=5^0+5^1+5^2+...
+        int numRarities = endingAt.getAsNumber() - startingAt.getAsNumber() + 1;
+        // Sum of n first elements in geometric series with a=1, r=5
+        int totalOdds = (1 - (int) Math.pow(5, numRarities)) / (1 - 5);
+        double numerator = Math.pow(5, numRarities - 1);
         for (int i = startingAt.getAsNumber(); i <= endingAt.getAsNumber(); i++) {
             Rarity currentRarity = Rarity.fromNumber(i);
-            odds.put(currentRarity, (remainingOdds / 5) * 4);
-            remainingOdds /= 5;
+            odds.put(currentRarity, numerator / totalOdds);
+            numerator /= 5;
         }
         return odds;
     }
-
 
     public static double getOdds(Rarity startingAt, Rarity endingAt, Rarity target) {
         return getOdds(startingAt, endingAt).get(target);


### PR DESCRIPTION
The current implementation of the `getOdds` function uses a simplified but incorrect formula to calculate the odds. This PR aims to fix the function to return accurate odds that match those released by Valve [here](https://www.csgo.com.cn/news/gamebroad/20170911/206155.shtml).

Here's an example of how the odds differ using a blue-purple-pink rarity item:

Old version:
```
blue: (1/5) * 4 = 4/5 = 80%
purple: (1/25) * 4 = 4/25 = 16%
pink: (1/125) * 4 = 4/125 = 3.2%
total: 80+16+3.2 = 99.2%
```

New version:
```
blue: 25/31 = ~80.645%
purple: 5/31 = ~16.129%
pink: 1/31 = ~3.226%
total: 100%
```

As can be seen, the new version is both more accurate, as the total odds add up to 100%, but the individual odds also line up with those released by Valve on the page linked above. Note that this formula does not apply to gold items, as those are only 2.5x rare than the previous tier (red). As such, the already present hardcoded case was left untouched.

I've also slightly updated the logging to round the official odds column to 3 decimal places for better readability.

The output now looks like:
```
Item distribution and odds calculation
Rarity name | Yours | Official
-------------------------------------------
blue     |           77/97 (~ 79.38 %) | 80.128%
purple   |           15/97 (~ 15.46 %) | 16.026%
pink     |            5/97 (~  5.15 %) | 3.205%
red      |            0/97 (~   0.0 %) | 0.641%

```

PS: I've also added the `data` folder to the `.gitignore` as it felt appropriate. I also haven't touched the version defined in the POM file, but I'd assume you would want to bump the version to 1.0.3 if you decide to merge this PR.