### PR TITLE
Fix `Press ENTER to continue...` prompt

### DIFF
--- a/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
+++ b/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
@@ -497,7 +497,9 @@ public class AnalysisService {
 
             System.out.println();
             System.out.println("Press ENTER to continue...");
-            System.in.readAllBytes();
+            while (System.in.read() != '\n') {
+            }
+
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The previous logic calls `System.in.readAllBytes()`, which blocks until EOF is detected. On stdin, this only happens if the user presses Ctrl-D. The new logic reads from stdin until a newline character is read.