### PR TITLE
Update formatting of fun stats

### DIFF
--- a/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
+++ b/src/main/java/de/cantry/csgocasestatsviewerv2/steam/service/AnalysisService.java
@@ -305,6 +305,10 @@ public class AnalysisService {
             }
         });
 
+        if (firstGoldDate.get() == null) {
+            longestDryTimeForGold.set(casesSinceLastGold.get());
+        }
+
         OddsUtils.getOddsForUnboxType(selectedUnboxType).forEach((rarity, chance) -> {
             logToConsoleRemoveColorAndFile(rarity.toString() + " (" + unboxedNames.getOrDefault(rarity, Collections.emptyList()).size() + ")", rarity);
             unboxedNames.getOrDefault(rarity, Collections.emptyList()).forEach(s -> logToConsoleRemoveColorAndFile(s, rarity));


### PR DESCRIPTION
Currently, when a user has never unboxed a gold item, the fun stats are formatted as follows:
```
"Fun" stats
First Gold in case Nr. 0 @ null
Longest streak of cases without Gold: 0
Cases since last Gold: 13
```

The longest streak is still set as 0, when, in this case, it should be set to 13:
```
"Fun" stats
First Gold in case Nr. 0 @ null
Longest streak of cases without Gold: 13
Cases since last Gold: 13
```

## Debatable
These fun stats don't exactly make sense when no golds have been unboxed:
* The date is `null` and shows case number 0
* Cases since last gold being set to the number of cases being opened isn't accurate; there are *no* cases since last gold since there is no last gold.
As such, I would propose these stats be formatted differently when the user has not unboxed a gold item:
```
"Sad" stats
Cases opened without Gold: X
Expected cases until Gold: OddsForGold - X
```

Let me know what you think about this suggestion, I am open to implementing it myself.